### PR TITLE
Added support for the transitive flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,25 @@ The previous invocation will download all the dependencies of
       transitive "false"
     end
 
+If you need to specify the destination filename, use the dest_file
+parameter.  If dest_file is not specified, this LWRP will assume that
+you want the artifact to be saved with the standard format
+artifactId-version.packaging. If you specify dest_file you can
+override that.  This comes in handy if you are downloading something
+like a web application (WAR file) and you want to save the file under
+a name that doesn't include the version.  Here's an example with the
+Apache Solr WAR file.  (Note that this example depends on the tomcat6
+cookbook and saves a WAR file to the webapps directory of Tomcat).
+
+    maven "solr" do
+      group_id "org.apache.solr"
+      version "3.6.0"
+      packaging "war"
+      dest "#{node[:tomcat6][:webapps]}"
+      dest_file "solr.war"
+      transitive "false"
+    end
+
 maven_repo
 ----------
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -19,11 +19,23 @@
 
 action :install do
   require 'fileutils'
+
+  
   # create the destination path if it doesn't already exist
   unless ::File.exists?(new_resource.dest)
     FileUtils.mkdir_p new_resource.dest, { :mode => 0755 }
   end
-  artifact_file = ::File.join new_resource.dest, "#{new_resource.artifact_id}-#{new_resource.version}.#{new_resource.packaging}"
+  
+  # Sometimes you want to grab something from a repository and save it under a 
+  # different filename.
+  dest_file = "#{new_resource.artifact_id}-#{new_resource.version}.#{new_resource.packaging}"
+  unless new_resource.dest_file.nil?
+    dest_file = new_resource.dest_file
+  end
+
+  artifact_file = ::File.join new_resource.dest, dest_file
+
+
   group_id = "-DgroupId=" + new_resource.group_id
   artifact_id = "-DartifactId=" + new_resource.artifact_id
   version = "-Dversion=" + new_resource.version

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -22,6 +22,7 @@ actions :install
 attribute :artifact_id, :kind_of => String
 attribute :group_id, :kind_of => String, :required => true
 attribute :dest, :kind_of => String
+attribute :dest_file, :kind_of => String
 attribute :version, :kind_of => String, :required => true
 attribute :packaging, :kind_of => String, :default => "jar"
 attribute :owner, :kind_of => String, :default => "root"


### PR DESCRIPTION
These commits add support for the transitive flag in the Maven LWRP.    This is necessary if you have a system that needs to download an artifact that might have some hefty dependencies.   If you are downloading a WAR file, there's often no need to go to the trouble of requesting all the dependencies (they are bundled with the application itself) - [COOK-1336]
