### PR TITLE
check the version attribute when invoking the default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,4 +22,4 @@
 
 include_recipe "java"
 
-include_recipe "maven::maven2"
+include_recipe "maven::maven#{node['maven']['version']}"


### PR DESCRIPTION
for issue COOK-1423:
default recipe should check node['maven']['version'] to allow the user to install maven3
