### PR TITLE
Add MAVEN_OPTS env var and add mvn to PATH.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,3 +29,4 @@ default['maven']['3']['url'] = 'http://apache.mirrors.tds.net/maven/binaries/apa
 default['maven']['3']['checksum'] = "d35a876034c08cb7e20ea2fbcf168bcad4dff5801abad82d48055517513faa2f"
 default['maven']['3']['plugin_version'] = "2.4"
 default['maven']['repositories'] = ["http://repo1.maven.apache.org/maven2"]
+default['maven']['opts'] = ''

--- a/recipes/maven2.rb
+++ b/recipes/maven2.rb
@@ -28,7 +28,7 @@ ark "maven" do
   append_env_path true
 end
 
-template "/etc/mavenrc" do
+template "/etc/profile.d/maven.sh" do
   source "mavenrc.erb"
   mode "0755"
 end

--- a/recipes/maven3.rb
+++ b/recipes/maven3.rb
@@ -30,7 +30,7 @@ ark "maven" do
   action :install
 end
 
-template "/etc/mavenrc" do
+template "/etc/profile.d/maven.sh" do
   source "mavenrc.erb"
   mode "0755"
 end

--- a/templates/default/mavenrc.erb
+++ b/templates/default/mavenrc.erb
@@ -1,4 +1,5 @@
 export M2_HOME=<%= node['maven']['m2_home'] %>
-export JAVA_HOME=<%= node['java']['java_home'] %>
+export MAVEN_HOME=<%= node['maven']['m2_home'] %>
+export MAVEN_OPTS="<%= node['maven']['opts'] %>"
 
-
+export PATH=$MAVEN_HOME/bin:$PATH


### PR DESCRIPTION
Removed export JAVA_HOME since that should be set by the java cookbook.

Added MAVEN_HOME alias for M2_HOME.   

Added MAVEN_OPTS env var for passing options to the jdk (max heap, etc).   Really useful for constructing build slaves.

Added MAVEN_HOME/bin to PATH
