### PR TITLE
[COOK-2116] Maven should be available on the path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 #*#
 *~
 .kitchen/
+
+# RubyMine
+/.idea

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Attributes
 * default['maven']['m3_download_url'] download url for maven3
 * default['maven']['m3_checksum'] the checksum, which you will have
  to recalculate if you change the download url
+* default['maven']['setup_bin'] Whether or not to put mvn on your
+ system path, defaults to false
 
 
 Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,3 +29,4 @@ default['maven']['3']['url'] = 'http://apache.mirrors.tds.net/maven/maven-3/3.0.
 default['maven']['3']['checksum'] = "d35a876034c08cb7e20ea2fbcf168bcad4dff5801abad82d48055517513faa2f"
 default['maven']['3']['plugin_version'] = "2.4"
 default['maven']['repositories'] = ["http://repo1.maven.apache.org/maven2"]
+default['maven']['setup_bin'] = false

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,3 +23,9 @@
 include_recipe "java"
 
 include_recipe "maven::maven#{node['maven']['version']}"
+
+if node['maven']['setup_bin']
+  link '/usr/bin/mvn' do
+    to "#{node['maven']['m2_home']}/bin/mvn"
+  end
+end


### PR DESCRIPTION
Controlled via attribute default['maven']['setup_bin'] which defaults to false to avoid messing with deployments which may contain maven installations not controlled by Chef.
- Added RubyMine IDE settings to .gitignore
- Added an option to link mvn binary to /usr/bin/mvn
