### PR TITLE
[COOK-1336] Make Transitive Flag Configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ maven
  ["http://repo1.maven.apache.org/maven2"]
 * owner: the owner of the resulting file, default is root
 * mode: integer value for file permissions, default is 0644
-
+* transitive: whether to resolve dependencies transitively, defaults to false. Please note: Event true will only place one artifact in dest. All others are downloaded to the local repository.
 
 # Examples
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -29,7 +29,8 @@ def create_command_string(artifact_file, new_resource)
   classifier = "-Dclassifier=" + new_resource.classifier if new_resource.classifier
   plugin_version = '2.4'
   plugin = "org.apache.maven.plugins:maven-dependency-plugin:#{plugin_version}:get"
-  %Q{mvn #{plugin} #{group_id} #{artifact_id} #{version} #{packaging} #{classifier} #{dest} #{repos}}
+  transitive = "-Dtransitive=" + new_resource.transitive.to_s()
+  %Q{mvn #{plugin} #{group_id} #{artifact_id} #{version} #{packaging} #{classifier} #{dest} #{repos} #{transitive}}
 end
 
 def get_mvn_artifact(action, new_resource)

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -28,6 +28,7 @@ attribute :classifier, :kind_of => String
 attribute :owner, :kind_of => String, :default => "root"
 attribute :mode, :kind_of => Integer, :default => 0644
 attribute :repositories, :kind_of => Array
+attribute :transitive, :kind_of => [ TrueClass, FalseClass ], :default => false
 
 alias :artifactId :artifact_id 
 alias :groupId :group_id 

--- a/test/kitchen/cookbooks/maven_test/recipes/default.rb
+++ b/test/kitchen/cookbooks/maven_test/recipes/default.rb
@@ -47,4 +47,5 @@ maven "solr-foo" do
   packaging "war"
   dest "/usr/local/foobar/lib"
   action :put
+  transitive true
 end


### PR DESCRIPTION
Previously all transitive dependencies where downloaded to the local
maven repository. The main Artefact was than copied to dest.

I changed the default behaviour to only download the main artifact. The
old behaviour can still be used with the attribute "transitive true".
