### PR TITLE
[COOK-2770] Fix broken maven3 support by moving from maven 3.0.4 to maven 3.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Attributes
 
 * default['maven']['version']  defaults to 2
 * default['maven']['m2_home']  defaults to  '/usr/local/maven/'
-* default['maven']['m2_download_url']  the download url for maven2
-* default['maven']['m2_checksum']  the checksum, which you will have
- to recalculate if you change the download url
-* default['maven']['m3_download_url'] download url for maven3
-* default['maven']['m3_checksum'] the checksum, which you will have
- to recalculate if you change the download url
+* default['maven']['2']['url']  the download url for maven2
+* default['maven']['2']['checksum']  the checksum, which you will have
+ to recalculate if you change the download url using shasum -a 256 <file>
+* default['maven']['3']['url'] download url for maven3
+* default['maven']['3']['checksum'] the checksum, which you will have
+ to recalculate if you change the download url using shasum -a 256 <file>
 * default['maven']['setup_bin'] Whether or not to put mvn on your
  system path, defaults to false
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,11 +22,11 @@
 
 default['maven']['version'] = 2
 default['maven']['m2_home'] = '/usr/local/maven'
-default['maven']['2']['url'] = "http://apache.mirrors.tds.net/maven/maven-2/2.2.1/binaries/apache-maven-2.2.1-bin.tar.gz"
+default['maven']['2']['url'] = 'http://www.us.apache.org/dist/maven/maven-2/2.2.1/binaries/apache-maven-2.2.1-bin.tar.gz'
 default['maven']['2']['checksum'] = "b9a36559486a862abfc7fb2064fd1429f20333caae95ac51215d06d72c02d376"
 default['maven']['2']['plugin_version'] = "2.4"
-default['maven']['3']['url'] = 'http://apache.mirrors.tds.net/maven/maven-3/3.0.4/binaries/apache-maven-3.0.4-bin.tar.gz'
-default['maven']['3']['checksum'] = "d35a876034c08cb7e20ea2fbcf168bcad4dff5801abad82d48055517513faa2f"
+default['maven']['3']['url'] = 'http://www.us.apache.org/dist/maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz'
+default['maven']['3']['checksum'] = "d98d766be9254222920c1d541efd466ae6502b82a39166c90d65ffd7ea357dd9"
 default['maven']['3']['plugin_version'] = "2.4"
 default['maven']['repositories'] = ["http://repo1.maven.apache.org/maven2"]
 default['maven']['setup_bin'] = false

--- a/recipes/maven3.rb
+++ b/recipes/maven3.rb
@@ -25,7 +25,7 @@ ark "maven" do
   url node['maven']['3']['url']
   checksum node['maven']['3']['checksum']
   home_dir node['maven']["m2_home"]
-  version "3.0.4"
+  version "3.0.5"
   append_env_path true
   action :install
 end


### PR DESCRIPTION
The current maven cookbook attempts to download the maven tarball from:

http://apache.mirrors.tds.net/maven/maven-3/3.0.4/binaries/apache-maven-3.0.4-bin.tar.gz

This URL is now returning 404 Not Found. This pull request addresses this problem, using a valid URL and bumping the maven version to 3.0.5

I also updated the README.md to reflect the proper config names, which seem to have gotten out of sync with what's implemented in the cookbook.
