### PR TITLE
[COOK-3352] Moved full path of repository_root attribute into attribute definition

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -22,7 +22,7 @@
 
 default['maven']['version'] = 2
 default['maven']['m2_home'] = '/usr/local/maven'
-default['maven']['repository_root'] = '/usr/local'
+default['maven']['repository_root'] = '/usr/local/m2/repository'
 default['maven']['2']['version'] = "2.2.1"
 default['maven']['2']['url'] = "http://apache.mirrors.tds.net/maven/maven-2/#{node['maven']['2']['version']}/binaries/apache-maven-#{node['maven']['2']['version']}-bin.tar.gz"
 default['maven']['2']['checksum'] = "b9a36559486a862abfc7fb2064fd1429f20333caae95ac51215d06d72c02d376"

--- a/templates/default/mavenrc.erb
+++ b/templates/default/mavenrc.erb
@@ -1,6 +1,4 @@
 export M2_HOME=<%= node['maven']['m2_home'] %>
 export JAVA_HOME=<%= node['java']['java_home'] %>
 
-export MAVEN_OPTS="-Dmaven.repo.local=<%= node['maven']['repository_root'] %>/m2/repository"
-
-
+export MAVEN_OPTS="-Dmaven.repo.local=<%= node['maven']['repository_root'] %>"


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3352

This will allow for full customization, e.g. to allow the standard behavior of having the local repository in $HOME/.m2/repository.
