### PR TITLE
[COOK-3457] Avoid bug [COOK-3118] in ark cookbook (< 0.3.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ The following Opscode cookbooks are dependencies:
 
 * java - this cookbook not only depends on the java virtual machine
   but it also depends on the java_ark LWRP present in the java cookbooks
-* ark - used to unpack the maven tarball
+* ark - used to download and unpack the maven tarball
+  * **Warning:** Due to bug [[COOK-3118]](http://tickets.opscode.com/browse/COOK-3118), maven cookbook cannot be integrated with ark 0.2.x and 0.3.0.
 
 Attributes
 ==========

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,8 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.16.3"
 
 depends "java"
-depends "ark"
+depends "ark", "< 0.2.0" # restriction due to [COOK-3118] 
+                         # (this problem will be fixed in upcoming ark 0.3.1)
 
 %w{ debian ubuntu centos redhat fedora }.each do |os|
   supports os


### PR DESCRIPTION
Related to http://tickets.opscode.com/browse/COOK-3457

See also opscode-cookbooks/ark#28 (fix for [COOK-3118])
