### PR TITLE
[COOK-3459] Bump Maven3 default version to 3.1.0

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -34,11 +34,12 @@ suites:
   - recipe[minitest-handler]
   - recipe[maven]
   - recipe[maven::test]
-  attributes: {}
+  attributes: { maven: { version: 2 } }
 
 - name: maven3
   run_list:
   - recipe[minitest-handler]
   - recipe[maven]
   - recipe[maven::test]
-  attributes: { maven: { version: 3 } }
+  attributes: {}
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The following Opscode cookbooks are dependencies:
 Attributes
 ==========
 
-* `node['maven']['version']`  defaults to 2, specifies the major
+* `node['maven']['version']`  defaults to 3, specifies the major
   version of maven to install.
 * `node['maven']['m2_home']`  defaults to  '/usr/local/maven/'
 * `node['maven']['2']['url']`  the download url for maven2

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,7 +20,7 @@
 # limitations under the License.
 #
 
-default['maven']['version'] = 2
+default['maven']['version'] = 3
 default['maven']['m2_home'] = '/usr/local/maven'
 default['maven']['repository_root'] = '/usr/local'
 default['maven']['2']['version'] = "2.2.1"


### PR DESCRIPTION
Related to http://tickets.opscode.com/browse/COOK-3459
