### PR TITLE
It should be possible to choose weather or not to create '/etc/mavenrc'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Attributes
   use; must be specified as an array. Used in the maven LWRP.
 * `node['maven']['setup_bin']` Whether or not to put mvn on your
  system path, defaults to false
+ * `node['maven']['create_mavenrc']` Whether or not to create the file
+ '/etc/mavenrc' based on the included template
 
 Recipes
 =======
@@ -118,6 +120,7 @@ License and Author
 - Author:: Seth Chisamore (<schisamo@opscode.com>)
 - Author:: Bryan W. Berry (<bryan.berry@gmail.com>)
 - Author:: Leif Madsen (<lmadsen@thinkingphones.com>)
+- Author:: Sander van Harmelen (<svanharmelen@schubergphilis.com>)
 
 Copyright 2010-2013, Opscode, Inc.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -33,3 +33,4 @@ default['maven']['3']['checksum'] = "d98d766be9254222920c1d541efd466ae6502b82a39
 default['maven']['3']['plugin_version'] = "2.4"
 default['maven']['repositories'] = ["http://repo1.maven.apache.org/maven2"]
 default['maven']['setup_bin'] = false
+default['maven']['create_mavenrc'] = true

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "cookbooks@opscode.com"
 license          "Apache 2.0"
 description      "Installs maven 2 or 3 and includes a maven resource."
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.16.5"
+version          "0.16.6"
 
 depends "java"
 depends "ark"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -36,4 +36,5 @@ end
 template "/etc/mavenrc" do
   source "mavenrc.erb"
   mode 00755
+  only_if { node['maven']['create_mavenrc'] }
 end


### PR DESCRIPTION
Since the template is not that extended and could need more of less
commands depending on your setup (e.g. -Xmx, -XX:MaxPermSize), so I
thought it would be best to make the standard template optional, so you
could also use a custom template
