### PR TITLE
Add "extra_opts" attribute to Maven resource

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -36,7 +36,8 @@ def create_command_string(artifact_file, new_resource)
   plugin_version = '2.4'
   plugin = "org.apache.maven.plugins:maven-dependency-plugin:#{plugin_version}:get"
   transitive = '-Dtransitive=' + new_resource.transitive.to_s
-  %Q{mvn #{plugin} #{group_id} #{artifact_id} #{version} #{packaging} #{classifier} #{dest} #{repos} #{transitive}}
+  extra_opts = new_resource.extra_opts
+  %Q{mvn #{extra_opts} #{plugin} #{group_id} #{artifact_id} #{version} #{packaging} #{classifier} #{dest} #{repos} #{transitive}}
 end
 
 def get_mvn_artifact(action, new_resource)

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -30,6 +30,7 @@ attribute :owner,        :kind_of => String, :default => 'root'
 attribute :mode,         :kind_of => [Integer, String], :default => '0644'
 attribute :repositories, :kind_of => Array
 attribute :transitive,   :kind_of => [TrueClass, FalseClass], :default => false
+attribute :extra_opts,   :kind_of => String
 
 alias_method :artifactId, :artifact_id # rubocop:disable SymbolName
 alias_method :groupId, :group_id # rubocop:disable SymbolName


### PR DESCRIPTION
This allows the user to specify additional command line options when calling mvn. For example, I use this attribute to tell Maven where to find pom.xml and settings.xml:

```extra_opts "-f #{home} -s #{home}/.m2/settings.xml"```