### PR TITLE
Support basic user setups

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -65,7 +65,7 @@ def get_mvn_artifact(action, new_resource)
 
       file dest_file do
         owner new_resource.owner
-        group new_resource.owner
+        group new_resource.group
         mode new_resource.mode
       end.run_action(:create)
 

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -27,6 +27,7 @@ attribute :version,      :kind_of => String, :required => true
 attribute :packaging,    :kind_of => String, :default => 'jar'
 attribute :classifier,   :kind_of => String
 attribute :owner,        :kind_of => String, :default => 'root'
+attribute :group,        :kind_of => String, :default => node['root_group']
 attribute :mode,         :kind_of => [Integer, String], :default => '0644'
 attribute :repositories, :kind_of => Array
 attribute :transitive,   :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
Support systems where there is no user group called "root".   Use the chef prescribed "root_group" which should already contain the correct group for "root" users for the OS.

Obvious fix