### PR TITLE
support newer java cookbook versions

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.1.1'
 
 depends 'ark',  '~> 0.4'
-depends 'java', '~> 1.13'
+depends 'java', '>=1.13'
 
 supports 'centos'
 supports 'debian'


### PR DESCRIPTION
The latest java cookbook is version 1.22.0 and does not satisfy the version constraint in the maven cookbook's metadata.rb. A 'berks install' fails when this combination of cookbooks is used. 

Assuming the intent was only to prevent versions before 1.13, this change will support the latest version of the java cookbook.  

I have tested and verified that this works with java cookbook 1.22.0