### PR TITLE
Optionally allow java to not be managed via the java cookbook.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Attributes
 * `node['maven']['repositories']` - an array of maven repositories to use; must be specified as an array. Used in the maven LWRP.
 * `node['maven']['setup_bin']` - Whether or not to put mvn on your system path, defaults to false
 * `node['maven']['mavenrc']['opts']` - Value of `MAVEN_OPTS` environment variable exported via `/etc/mavenrc` template, defaults to `-Dmaven.repo.local=$HOME/.m2/repository -Xmx384m -XX:MaxPermSize=192m`
+* `node['maven']['install_java']` - Whether or not to use the Java community cookbook to install Java. Defaults to `true`.
 
 
 Recipes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,3 +34,4 @@ default['maven']['3']['checksum'] = '077ed466455991d5abb4748a1d022e2d2a54dc4d557
 default['maven']['3']['plugin_version'] = '2.4'
 default['maven']['repositories'] = ['http://repo1.maven.apache.org/maven2']
 default['maven']['setup_bin'] = false
+default['maven']['install_java'] = true

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,7 +20,7 @@
 # limitations under the License.
 #
 
-include_recipe 'java::default'
+include_recipe 'java::default' if node['maven']['install_java']
 include_recipe 'ark::default'
 
 mvn_version = node['maven']['version'].to_s


### PR DESCRIPTION
There are use cases where Java is already installed or needs to be managed in a custom way. There should be a way for someone using the maven cookbook to tell it to not manage java for them. The Jenkins cookbook has taken a similar approach.

I will also be documenting guidelines for cookbook maintainers who depend on the java cookbook.

In reference to https://github.com/agileorbit-cookbooks/java/issues/190
