### PR TITLE
check if M2_HOME or MAVEN_OPTS has already been set before setting. 

### DIFF
--- a/templates/default/mavenrc.erb
+++ b/templates/default/mavenrc.erb
@@ -1,3 +1,3 @@
-export M2_HOME=<%= node['maven']['m2_home'] %>
+[ -z "$M2_HOME" ] && export M2_HOME=<%= node['maven']['m2_home'] %>
 
-export MAVEN_OPTS="<%= node['maven']['mavenrc']['opts'] %>"
+[ -z "$MAVEN_OPTS" ] && export MAVEN_OPTS="<%= node['maven']['mavenrc']['opts'] %>"


### PR DESCRIPTION
This will allow users/scripts to use a different version of Maven if required. The current setup will force you to the default installed version unless MAVEN_SKIP_RC is set. This seems a pain if all you want to do is override one or the other setting. 

I don't have a DigitalOcean account but I provided my own test-kitchen file to test and verify with Docker