### PR TITLE
Added setup_bin attribute to the 'append_env_path' option in the default...

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,7 +30,7 @@ ark 'maven' do
   checksum node['maven'][mvn_version]['checksum']
   home_dir node['maven']['m2_home']
   version  node['maven'][mvn_version]['version']
-  append_env_path true
+  append_env_path node['maven']['setup_bin']
 end
 
 template '/etc/mavenrc' do


### PR DESCRIPTION
I noticed that the default recipe doesn't use the `setup_bin` attribute. As per the ark cookbook documentation, 

`append_env_path`: If true, append the ./bin directory of the extracted directory to the PATH environment variable for all users, by placing a file in /etc/profile.d/. The commands are symbolically linked into /usr/bin/*. 

I have added this attribute to the default recipe. 