### PR TITLE
Configurable timeout for maven resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Providers/Resources
 - `owner` - the owner of the resulting file, default is root
 - `mode` - integer value for file permissions, default is 0644
 - `transitive` - whether to resolve dependencies transitively, defaults to false. Please note: Event true will only place one artifact in dest. All others are downloaded to the local repository.
+- `timeout` - sets the timeout (in seconds) of file download, default is 600
 
 #### Examples
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -52,7 +52,8 @@ def get_mvn_artifact(action, new_resource)
 
   Dir.mktmpdir('chef_maven_lwrp') do |tmp_dir|
     tmp_file = ::File.join(tmp_dir, artifact_file_name)
-    shell_out!(create_command_string(tmp_file, new_resource))
+    timeout = new_resource.timeout ? new_resource.timeout : 60
+    shell_out!(create_command_string(tmp_file, new_resource), :timeout => timeout)
     dest_file = ::File.join(new_resource.dest, artifact_file_name)
 
     unless ::File.exists?(dest_file) && checksum(tmp_file) == checksum(dest_file)

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -52,8 +52,7 @@ def get_mvn_artifact(action, new_resource)
 
   Dir.mktmpdir('chef_maven_lwrp') do |tmp_dir|
     tmp_file = ::File.join(tmp_dir, artifact_file_name)
-    timeout = new_resource.timeout ? new_resource.timeout : 60
-    shell_out!(create_command_string(tmp_file, new_resource), :timeout => timeout)
+    shell_out!(create_command_string(tmp_file, new_resource), :timeout => new_resource.timeout)
     dest_file = ::File.join(new_resource.dest, artifact_file_name)
 
     unless ::File.exists?(dest_file) && checksum(tmp_file) == checksum(dest_file)

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -27,6 +27,7 @@ attribute :version,      :kind_of => String, :required => true
 attribute :packaging,    :kind_of => String, :default => 'jar'
 attribute :classifier,   :kind_of => String
 attribute :owner,        :kind_of => String, :default => 'root'
+attribute :timeout,      :kind_of => [Integer, String], :default => '60'
 attribute :mode,         :kind_of => [Integer, String], :default => '0644'
 attribute :repositories, :kind_of => Array
 attribute :transitive,   :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -27,7 +27,7 @@ attribute :version,      :kind_of => String, :required => true
 attribute :packaging,    :kind_of => String, :default => 'jar'
 attribute :classifier,   :kind_of => String
 attribute :owner,        :kind_of => String, :default => 'root'
-attribute :timeout,      :kind_of => [Integer, String], :default => '600'
+attribute :timeout,      :kind_of => Integer, :default => 600
 attribute :mode,         :kind_of => [Integer, String], :default => '0644'
 attribute :repositories, :kind_of => Array
 attribute :transitive,   :kind_of => [TrueClass, FalseClass], :default => false

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -27,7 +27,7 @@ attribute :version,      :kind_of => String, :required => true
 attribute :packaging,    :kind_of => String, :default => 'jar'
 attribute :classifier,   :kind_of => String
 attribute :owner,        :kind_of => String, :default => 'root'
-attribute :timeout,      :kind_of => [Integer, String], :default => '60'
+attribute :timeout,      :kind_of => [Integer, String], :default => '600'
 attribute :mode,         :kind_of => [Integer, String], :default => '0644'
 attribute :repositories, :kind_of => Array
 attribute :transitive,   :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
When using `maven` LWRP for dowloading big artifacts, sometimes the operation takes more than 600 seconds and it fails for timeout; this Pull Request adds a `timeout` attribute in the `maven` resource that is passed to the `shell_out` command (thx @michaeldunstan for the suggestion)

Following https://github.com/maoo/maven/blob/master/TESTING.md, I've executed local runs with Kitchen, causing error by [setting timeout=1](https://github.com/maoo/artifact-deployer/blob/master/.kitchen.yml#L26); I've also tried to run rspec on the current Chef cookbook, but failed.

Also created an an account on https://tickets.opscode.com but not sure if I need to create a ticket there or not; please advise.