### PR TITLE
Loosen java cookbook depedency restriction.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.3.0'
 
 depends 'ark',  '~> 0.4'
-depends 'java', '~> 1.13'
+depends 'java', '>= 1.13'
 depends 'windows'
 
 supports 'centos'


### PR DESCRIPTION
The current versions of the Java cookbook use a higher minor version number. This allows a newer version to be used.