### PR TITLE
pass owner of maven installation to ark

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -21,6 +21,7 @@
 # limitations under the License.
 #
 
+default['maven']['owner'] = 'root'
 default['maven']['version'] = 3
 default['maven']['m2_home'] = '/usr/local/maven'
 default['maven']['mavenrc']['opts'] = '-Dmaven.repo.local=$HOME/.m2/repository -Xmx384m -XX:MaxPermSize=192m'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,6 +31,7 @@ ark 'maven' do
   home_dir        node['maven']['m2_home']
   win_install_dir node['maven']['m2_home']
   version         node['maven'][mvn_version]['version']
+  owner           node['maven']['owner']
   append_env_path true
 end
 


### PR DESCRIPTION
PR for the ability to define an owner for the maven binary. I can polish this PR with guidelines from https://github.com/opscode-cookbooks/maven/blob/master/CONTRIBUTING.md but first wanted to confirm this is the route to take, any intentional reasons this isn't in, etc.

Thanks