### PR TITLE
Use archive Apache URL for Maven 2.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,7 +25,7 @@ default['maven']['version'] = 3
 default['maven']['m2_home'] = '/usr/local/maven'
 default['maven']['mavenrc']['opts'] = '-Dmaven.repo.local=$HOME/.m2/repository -Xmx384m -XX:MaxPermSize=192m'
 default['maven']['2']['version'] = '2.2.1'
-default['maven']['2']['url'] = "http://apache.mirrors.tds.net/maven/maven-2/#{node['maven']['2']['version']}/binaries/apache-maven-#{node['maven']['2']['version']}-bin.tar.gz"
+default['maven']['2']['url'] = "http://archive.apache.org/dist/maven/binaries/apache-maven-#{node['maven']['2']['version']}-bin.tar.gz"
 default['maven']['2']['checksum'] = 'b9a36559486a862abfc7fb2064fd1429f20333caae95ac51215d06d72c02d376'
 default['maven']['2']['plugin_version'] = '2.4'
 default['maven']['3']['version'] = '3.1.1'


### PR DESCRIPTION
The [mirror](http://apache.mirrors.tds.net/maven/maven-2/) does not host Maven 2 anymore.