### PR TITLE
force update when downloading snapshots

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -32,13 +32,14 @@ def create_command_string(artifact_file, new_resource)
   artifact_id = '-DartifactId=' + new_resource.artifact_id
   version = '-Dversion=' + new_resource.version
   dest = '-Ddest=' + artifact_file
+  force_update = new_resource.version =~ /-SNAPSHOT$/ ? '-U' : ''
   repos = '-DremoteRepositories=' + new_resource.repositories.join(',')
   packaging = '-Dpackaging=' + new_resource.packaging
   classifier = '-Dclassifier=' + new_resource.classifier if new_resource.classifier
   plugin_version = '2.4'
   plugin = "org.apache.maven.plugins:maven-dependency-plugin:#{plugin_version}:get"
   transitive = '-Dtransitive=' + new_resource.transitive.to_s
-  %(mvn #{plugin} #{group_id} #{artifact_id} #{version} #{packaging} #{classifier} #{dest} #{repos} #{transitive})
+  %(mvn #{force_update} #{plugin} #{group_id} #{artifact_id} #{version} #{packaging} #{classifier} #{dest} #{repos} #{transitive})
 end
 
 def get_mvn_artifact(action, new_resource)


### PR DESCRIPTION
### Description

When the extension of the file contain `-SNAPSHOT` it will force update on every run by adding `-U` argument on maven command line.

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


