### PR TITLE
Make it possible to configure user/group to install Maven under

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Note: This cookbook does not handle the installation of Java but does require it
 - `node['maven']['repositories']` - an array of maven repositories to use; must be specified as an array. Used in the maven LWRP.
 - `node['maven']['setup_bin']` - whether or not to put mvn on your system path, defaults to false
 - `node['maven']['mavenrc']['opts']` - value of `MAVEN_OPTS` environment variable exported via `/etc/mavenrc` template, defaults to `-Dmaven.repo.local=$HOME/.m2/repository -Xmx384m`
+- `node['maven']['user']` - User to own Maven install, defaults to `root` or `Administrator` depending on platform.
+- `node['maven']['group']` - Group to own Maven install, defaults to `root` or `Administrators` depending on platform.
 
 ## Recipes
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,3 +29,15 @@ default['maven']['checksum'] = '707b1f6e390a65bde4af4cdaf2a24d45fc19a6ded00fff02
 default['maven']['plugin_version'] = '2.10'
 default['maven']['repositories'] = ['http://repo1.maven.apache.org/maven']
 default['maven']['setup_bin'] = true
+default['maven']['user'] = case node['platform_family']
+when 'windows'
+  'Administrator'
+else
+  'root'
+end
+default['maven']['group'] = case node['platform_family']
+when 'windows'
+  'Administrators'
+else
+  'root'
+end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,6 +22,18 @@
 
 include_recipe 'ark::default'
 
+group 'create the group for Maven' do
+  group_name node['maven']['group']
+  not_if { node['maven']['group'] == 'root' || node['maven']['group'] == 'Administrators' }
+end
+
+user 'create the user for Maven' do
+  username node['maven']['user']
+  group node['maven']['group']
+  manage_home true
+  not_if { node['maven']['user'] == 'root' || node['maven']['user'] == 'Administrator' }
+end
+
 # install maven via ark
 ark 'maven' do
   version node['maven']['version']
@@ -30,6 +42,8 @@ ark 'maven' do
   home_dir node['maven']['m2_home']
   win_install_dir node['maven']['m2_home']
   append_env_path node['maven']['setup_bin']
+  owner node['maven']['user']
+  group node['maven']['group']
 end
 
 # setup environmental variables

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -27,9 +27,8 @@ describe 'default recipe' do
   end
 
   it 'writes the `/etc/mavenrc`' do
-    template = chef_run.template('/etc/mavenrc')
-    expect(template).to be
-    expect(template.source).to eq('mavenrc.erb')
-    expect(template.mode).to eq('0755')
+    expect(chef_run).to create_template('/etc/mavenrc')
+      .with(source: 'mavenrc.erb')
+      .with(mode: '0755')
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'default recipe' do
+describe 'maven::default' do
   context 'When the platform doesn\'t matter' do
     cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
@@ -10,7 +10,7 @@ describe 'default recipe' do
         node.automatic['maven']['m2_home'] = '/home/maven-user'
         node.automatic['maven']['setup_bin'] = false
       end
-      runner.converge('maven::default')
+      runner.converge(described_recipe)
     end
 
     it 'includes the ark recipe' do
@@ -31,7 +31,7 @@ describe 'default recipe' do
   context 'On a non-Windows platform' do
     cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
-      runner.converge('maven::default')
+      runner.converge(described_recipe)
     end
 
     it 'writes the `/etc/mavenrc`' do
@@ -47,7 +47,7 @@ describe 'default recipe' do
         node.automatic['maven']['m2_home'] = 'C:\Users\Maven-User'
         node.automatic['maven']['mavenrc']['opts'] = '-Ddummy=true'
       end
-      runner.converge('maven::default')
+      runner.converge(described_recipe)
     end
 
     it 'sets the M2_HOME environment variable' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -2,7 +2,13 @@ require 'spec_helper'
 
 describe 'default recipe' do
   cached(:chef_run) do
-    runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
+    runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+      node.automatic['maven']['version'] = '1.2.3'
+      node.automatic['maven']['url'] = 'https://maven/maven.tar.gz'
+      node.automatic['maven']['checksum'] = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+      node.automatic['maven']['m2_home'] = '/home/maven-user'
+      node.automatic['maven']['setup_bin'] = false
+    end
     runner.converge('maven::default')
   end
 
@@ -12,6 +18,12 @@ describe 'default recipe' do
 
   it 'downloads ark' do
     expect(chef_run).to install_ark('maven')
+      .with(version: '1.2.3')
+      .with(url: 'https://maven/maven.tar.gz')
+      .with(checksum: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+      .with(home_dir: '/home/maven-user')
+      .with(win_install_dir: '/home/maven-user')
+      .with(append_env_path: false)
   end
 
   it 'writes the `/etc/mavenrc`' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -3,61 +3,193 @@ require 'spec_helper'
 describe 'maven::default' do
   context 'When the platform doesn\'t matter' do
     cached(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
-        node.automatic['maven']['version'] = '1.2.3'
-        node.automatic['maven']['url'] = 'https://maven/maven.tar.gz'
-        node.automatic['maven']['checksum'] = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
-        node.automatic['maven']['m2_home'] = '/home/maven-user'
-        node.automatic['maven']['setup_bin'] = false
-      end
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
       runner.converge(described_recipe)
     end
 
     it 'includes the ark recipe' do
       expect(chef_run).to include_recipe('ark::default')
     end
-
-    it 'downloads ark' do
-      expect(chef_run).to install_ark('maven')
-        .with(version: '1.2.3')
-        .with(url: 'https://maven/maven.tar.gz')
-        .with(checksum: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
-        .with(home_dir: '/home/maven-user')
-        .with(win_install_dir: '/home/maven-user')
-        .with(append_env_path: false)
-    end
   end
 
   context 'On a non-Windows platform' do
-    cached(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
-      runner.converge(described_recipe)
+    context 'When Maven owner and group are not important' do
+      cached(:chef_run) do
+        runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
+        runner.converge(described_recipe)
+      end
+
+      it 'writes the `/etc/mavenrc`' do
+        expect(chef_run).to create_template('/etc/mavenrc')
+          .with(source: 'mavenrc.erb')
+          .with(mode: '0755')
+      end
     end
 
-    it 'writes the `/etc/mavenrc`' do
-      expect(chef_run).to create_template('/etc/mavenrc')
-        .with(source: 'mavenrc.erb')
-        .with(mode: '0755')
+    context 'When Maven owner and group are not overriden' do
+      cached(:chef_run) do
+        runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+          node.automatic['maven']['version'] = '1.2.3'
+          node.automatic['maven']['url'] = 'https://maven/maven.tar.gz'
+          node.automatic['maven']['checksum'] = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          node.automatic['maven']['m2_home'] = '/home/maven-user'
+          node.automatic['maven']['setup_bin'] = false
+        end
+        runner.converge(described_recipe)
+      end
+
+      it 'does not create a group' do
+        expect(chef_run).to_not create_group('create the group for Maven')
+      end
+
+      it 'does not create a user' do
+        expect(chef_run).to_not create_user('create the user for Maven')
+      end
+
+      it 'downloads ark' do
+        expect(chef_run).to install_ark('maven')
+          .with(version: '1.2.3')
+          .with(url: 'https://maven/maven.tar.gz')
+          .with(checksum: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+          .with(home_dir: '/home/maven-user')
+          .with(win_install_dir: '/home/maven-user')
+          .with(append_env_path: false)
+          .with(owner: 'root')
+          .with(group: 'root')
+      end
+    end
+
+    context 'When Maven owner and group are overriden' do
+      cached(:chef_run) do
+        runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+          node.automatic['maven']['version'] = '1.2.3'
+          node.automatic['maven']['url'] = 'https://maven/maven.tar.gz'
+          node.automatic['maven']['checksum'] = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          node.automatic['maven']['m2_home'] = '/home/maven-user'
+          node.automatic['maven']['setup_bin'] = false
+          node.automatic['maven']['user'] = 'maven-user'
+          node.automatic['maven']['group'] = 'maven-group'
+        end
+        runner.converge(described_recipe)
+      end
+
+      it 'creates a group' do
+        expect(chef_run).to create_group('create the group for Maven')
+          .with(group_name: 'maven-group')
+      end
+
+      it 'creates a user' do
+        expect(chef_run).to create_user('create the user for Maven')
+          .with(username: 'maven-user')
+          .with(manage_home: true)
+          .with(group: 'maven-group')
+      end
+
+      it 'downloads ark' do
+        expect(chef_run).to install_ark('maven')
+          .with(version: '1.2.3')
+          .with(url: 'https://maven/maven.tar.gz')
+          .with(checksum: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+          .with(home_dir: '/home/maven-user')
+          .with(win_install_dir: '/home/maven-user')
+          .with(append_env_path: false)
+          .with(owner: 'maven-user')
+          .with(group: 'maven-group')
+      end
     end
   end
 
   context 'On a Windows platform' do
-    cached(:chef_run) do
-      runner = ChefSpec::ServerRunner.new(platform: 'windows', version: '7') do |node|
-        node.automatic['maven']['m2_home'] = 'C:\Users\Maven-User'
-        node.automatic['maven']['mavenrc']['opts'] = '-Ddummy=true'
+    context 'When Maven owner and group are not important' do
+      cached(:chef_run) do
+        runner = ChefSpec::ServerRunner.new(platform: 'windows', version: '7') do |node|
+          node.automatic['maven']['m2_home'] = 'C:\Users\Maven-User'
+          node.automatic['maven']['mavenrc']['opts'] = '-Ddummy=true'
+        end
+        runner.converge(described_recipe)
       end
-      runner.converge(described_recipe)
+
+      it 'sets the M2_HOME environment variable' do
+        expect(chef_run).to create_env('M2_HOME')
+          .with(value: 'C:\Users\Maven-User')
+      end
+
+      it 'sets the M2_OPTS' do
+        expect(chef_run).to create_env('MAVEN_OPTS')
+          .with(value: '-Ddummy=true')
+      end
     end
 
-    it 'sets the M2_HOME environment variable' do
-      expect(chef_run).to create_env('M2_HOME')
-        .with(value: 'C:\Users\Maven-User')
+    context 'When Maven owner and group are not overriden' do
+      cached(:chef_run) do
+        runner = ChefSpec::ServerRunner.new(platform: 'windows', version: '7') do |node|
+          node.automatic['maven']['version'] = '1.2.3'
+          node.automatic['maven']['url'] = 'https://maven/maven.tar.gz'
+          node.automatic['maven']['checksum'] = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          node.automatic['maven']['m2_home'] = 'C:\Users\Maven-User'
+          node.automatic['maven']['setup_bin'] = false
+        end
+        runner.converge(described_recipe)
+      end
+
+      it 'does not create a group' do
+        expect(chef_run).to_not create_group('create the group for Maven')
+      end
+
+      it 'does not create a user' do
+        expect(chef_run).to_not create_user('create the user for Maven')
+      end
+
+      it 'downloads ark' do
+        expect(chef_run).to install_ark('maven')
+          .with(version: '1.2.3')
+          .with(url: 'https://maven/maven.tar.gz')
+          .with(checksum: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+          .with(home_dir: 'C:\Users\Maven-User')
+          .with(win_install_dir: 'C:\Users\Maven-User')
+          .with(append_env_path: false)
+          .with(owner: 'Administrator')
+          .with(group: 'Administrators')
+      end
     end
 
-    it 'sets the M2_OPTS' do
-      expect(chef_run).to create_env('MAVEN_OPTS')
-        .with(value: '-Ddummy=true')
+    context 'When Maven owner and group are overriden' do
+      cached(:chef_run) do
+        runner = ChefSpec::ServerRunner.new(platform: 'windows', version: '7') do |node|
+          node.automatic['maven']['version'] = '1.2.3'
+          node.automatic['maven']['url'] = 'https://maven/maven.tar.gz'
+          node.automatic['maven']['checksum'] = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+          node.automatic['maven']['m2_home'] = 'C:\Users\Maven-User'
+          node.automatic['maven']['setup_bin'] = false
+          node.automatic['maven']['user'] = 'Wibble'
+          node.automatic['maven']['group'] = 'Group'
+        end
+        runner.converge(described_recipe)
+      end
+
+      it 'creates a group' do
+        expect(chef_run).to create_group('create the group for Maven')
+          .with(group_name: 'Group')
+      end
+
+      it 'creates a user' do
+        expect(chef_run).to create_user('create the user for Maven')
+          .with(username: 'Wibble')
+          .with(manage_home: true)
+          .with(group: 'Group')
+      end
+
+      it 'downloads ark' do
+        expect(chef_run).to install_ark('maven')
+          .with(version: '1.2.3')
+          .with(url: 'https://maven/maven.tar.gz')
+          .with(checksum: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+          .with(home_dir: 'C:\Users\Maven-User')
+          .with(win_install_dir: 'C:\Users\Maven-User')
+          .with(append_env_path: false)
+          .with(owner: 'Wibble')
+          .with(group: 'Group')
+      end
     end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,34 +1,63 @@
 require 'spec_helper'
 
 describe 'default recipe' do
-  cached(:chef_run) do
-    runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
-      node.automatic['maven']['version'] = '1.2.3'
-      node.automatic['maven']['url'] = 'https://maven/maven.tar.gz'
-      node.automatic['maven']['checksum'] = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
-      node.automatic['maven']['m2_home'] = '/home/maven-user'
-      node.automatic['maven']['setup_bin'] = false
+  context 'When the platform doesn\'t matter' do
+    cached(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04') do |node|
+        node.automatic['maven']['version'] = '1.2.3'
+        node.automatic['maven']['url'] = 'https://maven/maven.tar.gz'
+        node.automatic['maven']['checksum'] = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'
+        node.automatic['maven']['m2_home'] = '/home/maven-user'
+        node.automatic['maven']['setup_bin'] = false
+      end
+      runner.converge('maven::default')
     end
-    runner.converge('maven::default')
+
+    it 'includes the ark recipe' do
+      expect(chef_run).to include_recipe('ark::default')
+    end
+
+    it 'downloads ark' do
+      expect(chef_run).to install_ark('maven')
+        .with(version: '1.2.3')
+        .with(url: 'https://maven/maven.tar.gz')
+        .with(checksum: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
+        .with(home_dir: '/home/maven-user')
+        .with(win_install_dir: '/home/maven-user')
+        .with(append_env_path: false)
+    end
   end
 
-  it 'includes the ark recipe' do
-    expect(chef_run).to include_recipe('ark::default')
+  context 'On a non-Windows platform' do
+    cached(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
+      runner.converge('maven::default')
+    end
+
+    it 'writes the `/etc/mavenrc`' do
+      expect(chef_run).to create_template('/etc/mavenrc')
+        .with(source: 'mavenrc.erb')
+        .with(mode: '0755')
+    end
   end
 
-  it 'downloads ark' do
-    expect(chef_run).to install_ark('maven')
-      .with(version: '1.2.3')
-      .with(url: 'https://maven/maven.tar.gz')
-      .with(checksum: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')
-      .with(home_dir: '/home/maven-user')
-      .with(win_install_dir: '/home/maven-user')
-      .with(append_env_path: false)
-  end
+  context 'On a Windows platform' do
+    cached(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'windows', version: '7') do |node|
+        node.automatic['maven']['m2_home'] = 'C:\Users\Maven-User'
+        node.automatic['maven']['mavenrc']['opts'] = '-Ddummy=true'
+      end
+      runner.converge('maven::default')
+    end
 
-  it 'writes the `/etc/mavenrc`' do
-    expect(chef_run).to create_template('/etc/mavenrc')
-      .with(source: 'mavenrc.erb')
-      .with(mode: '0755')
+    it 'sets the M2_HOME environment variable' do
+      expect(chef_run).to create_env('M2_HOME')
+        .with(value: 'C:\Users\Maven-User')
+    end
+
+    it 'sets the M2_OPTS' do
+      expect(chef_run).to create_env('MAVEN_OPTS')
+        .with(value: '-Ddummy=true')
+    end
   end
 end


### PR DESCRIPTION
### Description

It was found in #82 that it is not possible to configure the user/group that Maven is installed under. This change makes that possible, and creates that user/group if required.

Additionally, this adds some more tests for the `maven::default` recipe.

Re-opened after refactoring from #87.

### Issues Resolved

Closes #82.

### Check List

[x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
[x] New functionality includes testing.
[x] New functionality has been documented in the README if applicable
[x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
