### PR TITLE
fix: preserve existing destination dir permissions

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -88,6 +88,7 @@ action_class do
           directory new_resource.dest do
             recursive true
             mode '0755'
+            not_if { ::Dir.exist?(new_resource.dest) }
           end.run_action(:create)
 
           FileUtils.cp(tmp_file, dest_file, preserve: true)

--- a/spec/unit/resources/default_spec.rb
+++ b/spec/unit/resources/default_spec.rb
@@ -1,0 +1,48 @@
+require 'etc'
+require 'spec_helper'
+require 'tmpdir'
+
+describe 'maven custom resource' do
+  let(:current_user) { Etc.getpwuid(Process.uid).name }
+  let(:current_group) { Etc.getgrgid(Process.gid).name }
+  let(:dest_dir) { Dir.mktmpdir('maven-dest') }
+  let(:build_dir) { Dir.mktmpdir('maven-build') }
+  let(:artifact_name) { 'mysql-connector-java-5.1.19.jar' }
+  let(:artifact_path) { ::File.join(dest_dir, artifact_name) }
+  let(:build_artifact_path) { ::File.join(build_dir, artifact_name) }
+
+  around do |example|
+    ::File.chmod(0o700, dest_dir)
+    example.run
+  ensure
+    ::FileUtils.remove_entry(dest_dir) if ::Dir.exist?(dest_dir)
+    ::FileUtils.remove_entry(build_dir) if ::Dir.exist?(build_dir)
+  end
+
+  cached(:chef_run) do
+    allow(Dir).to receive(:mktmpdir).with('chef_maven_lwrp').and_yield(build_dir)
+    allow_any_instance_of(Chef::Provider).to receive(:shell_out!) do |_provider, *_args, **_kwargs|
+      ::File.write(build_artifact_path, 'artifact-bits')
+    end
+
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      step_into: ['maven'],
+      cookbook_path: [
+        ::File.expand_path('../../../', __dir__),
+        ::File.expand_path('../../../test/fixtures/cookbooks', __dir__),
+      ]
+    ) do |node|
+      node.normal['maven_test']['dest'] = dest_dir
+      node.normal['maven_test']['owner'] = current_user
+      node.normal['maven_test']['group'] = current_group
+    end.converge('test::existing_dest_mode')
+  end
+
+  it 'preserves an existing destination directory mode' do
+    chef_run
+
+    expect(::File.stat(dest_dir).mode & 0o7777).to eq(0o700)
+    expect(::File.exist?(artifact_path)).to eq(true)
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/existing_dest_mode.rb
+++ b/test/fixtures/cookbooks/test/recipes/existing_dest_mode.rb
@@ -1,0 +1,7 @@
+maven 'mysql-connector-java' do
+  group_id 'mysql'
+  version  '5.1.19'
+  dest     node['maven_test']['dest']
+  owner    node['maven_test']['owner']
+  group    node['maven_test']['group']
+end


### PR DESCRIPTION
## Summary
- preserve permissions on existing destination directories when the maven resource downloads an artifact
- add a targeted ChefSpec regression fixture for an existing destination directory

## Root cause
The custom resource always created the destination directory with mode 0755 before copying the artifact, so pointing dest at an existing path such as /tmp could chmod that directory during converge.

## Validation
- cookstyle resources/default.rb spec/unit/resources/default_spec.rb test/fixtures/cookbooks/test/recipes/existing_dest_mode.rb
- ruby -c spec/unit/resources/default_spec.rb
- ruby -c test/fixtures/cookbooks/test/recipes/existing_dest_mode.rb
- rspec spec/unit/resources/default_spec.rb (blocked locally by conflicting ChefSpec/RSpec gems and ChefSpec attempting to bind 127.0.0.1:8889 in this environment)

Fixes #85