### PR TITLE
fix: preserve destination directory permissions

### DIFF
--- a/resources/artifact.rb
+++ b/resources/artifact.rb
@@ -117,10 +117,11 @@ action_class do
     dest_dir = new_resource.dest
     dest_file = ::File.join(dest_dir, file_name)
 
-    directory dest_dir do
-      recursive true
-      mode '0755'
-      action :create
+    ruby_block "create destination directory #{dest_dir}" do
+      block do
+        FileUtils.mkdir_p(dest_dir)
+      end
+      not_if { ::Dir.exist?(dest_dir) }
     end
 
     shell_out!(mvn_command, timeout: new_resource.timeout)

--- a/spec/unit/resources/artifact_spec.rb
+++ b/spec/unit/resources/artifact_spec.rb
@@ -6,6 +6,39 @@ describe 'maven_artifact' do
   step_into :maven_artifact
   platform 'ubuntu', '24.04'
 
+  context 'with the install action' do
+    let(:cached_file) do
+      ::File.join(
+        ENV.fetch('HOME', Dir.home),
+        '.m2', 'repository', 'org/apache/commons', 'commons-lang3', '3.17.0', 'commons-lang3-3.17.0.jar'
+      )
+    end
+
+    before do
+      allow_any_instance_of(Chef::Provider).to receive(:shell_out!).and_return(double('shell_out'))
+      allow(::File).to receive(:exist?).and_call_original
+      allow(::File).to receive(:exist?).with(cached_file).and_return(true)
+      allow(::File).to receive(:exist?).with('/srv/maven-artifacts/commons-lang3-3.17.0.jar').and_return(true)
+      allow(::Dir).to receive(:exist?).and_call_original
+      allow(::Dir).to receive(:exist?).with('/srv/maven-artifacts').and_return(true)
+      allow(Digest::SHA256).to receive_message_chain(:file, :hexdigest).and_return('abc123')
+    end
+
+    recipe do
+      maven_artifact 'commons-lang3' do
+        group_id 'org.apache.commons'
+        version '3.17.0'
+        dest '/srv/maven-artifacts'
+      end
+    end
+
+    it 'creates the destination directory via a ruby_block without managing directory mode' do
+      expect(chef_run.find_resource(:ruby_block, 'create destination directory /srv/maven-artifacts')).to be
+    end
+
+    it { is_expected.to_not create_directory('/srv/maven-artifacts') }
+  end
+
   context 'with the delete action' do
     recipe do
       maven_artifact 'commons-logging-custom' do


### PR DESCRIPTION
## Summary
- stop the maven_artifact resource from changing permissions on an existing destination directory
- create the destination path only when it is missing
- add a ChefSpec regression test covering the destination-directory behavior

Closes #85