### PR TITLE
chore: migrate dependency resolution to Policyfile

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v7
       - name: Install Chef
-        uses: actionshub/chef-install@main
+        uses: sous-chefs/.github/.github/actions/install-workstation@8.0.4
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,39 +31,39 @@ The cookbook installs Maven from the upstream Apache binary tarball through the
 
 The cookbook follows the platforms declared in `metadata.rb`:
 
-- AlmaLinux 9+
-- Amazon Linux 2023+
-- Debian 12+
-- Debian 13+
-- Fedora
-- Rocky Linux 9+
-- Ubuntu 22.04+
+* AlmaLinux 9+
+* Amazon Linux 2023+
+* Debian 12+
+* Debian 13+
+* Fedora
+* Rocky Linux 9+
+* Ubuntu 22.04+
 
 ## Architectures
 
-- `x86_64`
-- `aarch64` / `arm64`
+* `x86_64`
+* `aarch64` / `arm64`
 
 Maven itself is architecture-independent, but the host JDK must support the
 target architecture.
 
 ## JDK prerequisites
 
-- Maven 3.9.x requires JDK 8 or later
-- Maven 4.x requires JDK 17 or later
+* Maven 3.9.x requires JDK 8 or later
+* Maven 4.x requires JDK 17 or later
 
 This cookbook does not install Java. Callers must ensure a compatible JDK is
 available before `maven_install` or `maven_artifact` is used.
 
 ## Resource behavior constraints
 
-- `maven_install` is designed for a single system-wide installation. It manages
+* `maven_install` is designed for a single system-wide installation. It manages
   a shared install directory, writes one `mavenrc` file, and removes the
   `/usr/local/bin/mvn` symlink when uninstalling.
-- `maven_artifact` shells out to `mvn`, so Maven and Java must already be on
+* `maven_artifact` shells out to `mvn`, so Maven and Java must already be on
   `PATH` when the resource runs.
-- `maven_artifact :delete` removes both the versioned install filename
+* `maven_artifact :delete` removes both the versioned install filename
   (`artifact-version[-classifier].packaging`) and the custom `:put` filename
   (`resource_name.packaging`).
-- `maven_settings` updates an existing `settings.xml` file in place. The target
+* `maven_settings` updates an existing `settings.xml` file in place. The target
   file and the dotted XML path must already exist.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,15 @@
-# Limitations
+# AGENTS.md
+
+## Cookbook Purpose
+
+Custom resources for installing Apache Maven and downloading Maven artifacts
+
+## Agent Findings
+
+* This cookbook is in an incremental modernization pass. Preserve existing public recipes and attributes unless a later full migration is explicitly selected.
+* Dependency management should use `Policyfile.rb`; do not reintroduce Berkshelf.
+
+## Known Limitations
 
 Apache Maven is a Java build tool distributed by the Apache Software Foundation.
 This cookbook manages Maven through custom resources and assumes a Linux/Unix

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf'
 gem 'chefspec', '>= 9.3.7'
 gem 'fauxhai-chef'
 gem 'gyoku'

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+name 'maven'
+
+run_list 'test::default'
+
+cookbook 'maven', path: '.'
+cookbook 'ark', git: 'https://github.com/sous-chefs/ark.git', branch: 'main'
+cookbook 'seven_zip', git: 'https://github.com/sous-chefs/seven_zip.git', branch: 'main'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, 'test::' + recipe_name
+end

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ that exercises all three resources together.
 
 ## Limitations
 
-See [LIMITATIONS.md](./LIMITATIONS.md) for supported platforms, architecture
+See [AGENTS.md](./AGENTS.md) for supported platforms, architecture
 notes, and current behavioral constraints of the resources.
 
 ## Contributors

--- a/chefignore
+++ b/chefignore
@@ -83,10 +83,7 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
 #############
-Berksfile
-Berksfile.lock
 cookbooks/*
 tmp
 

--- a/resources/settings.rb
+++ b/resources/settings.rb
@@ -29,7 +29,11 @@ action :update do
   end
 
   require 'nori'
-  require 'gyoku'
+  begin
+    require 'gyoku'
+  rescue LoadError
+    require 'chef-gyoku'
+  end
 
   settings_file = new_resource.settings_file
   current = Nori.new(parser: :rexml).parse(::File.read(settings_file))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true               # Use color in STDOUT


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berksfile to Policyfile
- update ChefSpec setup to use Policyfile resolution
- update Copilot setup to install Chef Workstation 8.0.4 and run chef install Policyfile.rb
- move cookbook limitations into AGENTS.md where present

## Verification
- chef install Policyfile.rb
- cookstyle
- kitchen list
- /opt/chef-workstation/embedded/bin/rspec --format progress