### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.4
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@9.0.0
     permissions:
       actions: write
       checks: write

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -7,8 +7,6 @@ default_source :supermarket
 run_list 'test::default'
 
 cookbook 'maven', path: '.'
-cookbook 'ark', git: 'https://github.com/sous-chefs/ark.git', branch: 'main'
-cookbook 'seven_zip', git: 'https://github.com/sous-chefs/seven_zip.git', branch: 'main'
 cookbook 'test', path: './test/cookbooks/test'
 
 Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -2,6 +2,8 @@
 
 name 'maven'
 
+default_source :supermarket
+
 run_list 'test::default'
 
 cookbook 'maven', path: '.'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -11,6 +11,7 @@ provisioner:
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
+  always_update_cookbooks: false
 
 verifier:
   name: inspec

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -26,10 +26,6 @@ platforms:
   - name: ubuntu-22.04
   - name: ubuntu-24.04
 
-x-run_lists:
-  default: &default_run_list
-    - recipe[test::default]
-
 x-verifiers:
   default: &default_verifier
     inspec_tests:
@@ -37,5 +33,6 @@ x-verifiers:
 
 suites:
   - name: default
-    run_list: *default_run_list
+    provisioner:
+      named_run_list: default
     verifier: *default_verifier


### PR DESCRIPTION
## Summary
- Add explicit Policyfile default source and resolve cookbook dependencies from metadata/Supermarket with the current cookbook from `path: '.'`.
- Use Policyfile named run list selection in Kitchen for the default suite.
- Disable forced Kitchen cookbook updates after Policyfile install to avoid runner git-cache hardlink failures.
- Pin the sous-chefs lint-unit reusable workflow to `@9.0.0`.

## Validation
- `chef update Policyfile.rb`: passed (rerun outside sandbox so Chef Workstation could reach Supermarket)
- `cookstyle`: passed, 15 files inspected, no offenses
- `chef exec rspec --format documentation`: blocked locally by macOS code-signing issue in `~/.chef/gem` json native extension
- `env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation`: passed, 17 examples, 0 failures
- `actionlint`: passed
- `yamllint .`: passed
- `markdownlint-cli2 '**/*.md'`: passed, 9 files, 0 errors
- `git diff --check`: passed
- `KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list`: passed
- `KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen diagnose default-ubuntu-2404`: passed; confirmed `named_run_list: default` and `always_update_cookbooks: false`
- `KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen test default-ubuntu-2404 --destroy=always`: locally reached Policyfile install/export and converge, then failed on local Docker SSL certificate validation downloading the Maven tarball from `archive.apache.org`

## Hosted Checks
- GitHub Actions `lint-unit`: passed
- GitHub Actions integration matrix: passed for `almalinux-9`, `amazonlinux-2023`, `debian-12`, `debian-13`, `fedora-latest`, `rockylinux-9`, `ubuntu-2204`, `ubuntu-2404`
